### PR TITLE
jsonrpc module update

### DIFF
--- a/src/ids/mod.rs
+++ b/src/ids/mod.rs
@@ -173,7 +173,7 @@ impl<'de> Deserialize<'de> for Id {
     where
         D: Deserializer<'de>,
     {
-        let s: &str = Deserialize::deserialize(deserializer)?;
+        let s: String = Deserialize::deserialize(deserializer)?;
         Id::from_str(&s).map_err(serde::de::Error::custom)
     }
 }

--- a/src/ids/node.rs
+++ b/src/ids/node.rs
@@ -140,7 +140,7 @@ impl<'de> Deserialize<'de> for Id {
     where
         D: Deserializer<'de>,
     {
-        let s: &str = Deserialize::deserialize(deserializer)?;
+        let s: String = Deserialize::deserialize(deserializer)?;
         Id::from_str(&s).map_err(serde::de::Error::custom)
     }
 }


### PR DESCRIPTION
### Description

This PR is the first effort to update `jsonrpc` structs to match the recent API updates. See #33 for more details.

**Note:** I only focused on `ApiPrimaryValidator` and `ApiPrimaryDelegator` for now.

### Changes

- `ids` and `ids::node`: Allow to deserialize `Id`s from `String`. I had problems using `ureq` with the previous implementation that only supported `&str`.
- `ApiPrimaryValidator`:
  - Remove deprecated fields: `staked`, `reward_owner`
  - Add new fields: `validation_reward_owner`, `delegation_reward_owner`, `delegator_count`, `delegator_weight`, `signer`
  - Remove `Option` for fields: `connected` and `uptime` that are not optional (based on the API docs)
  - Use `serde(rename_all = "camelCase")` to make struct more readable
- `ApiPrimaryDelegator`:
  - Remove deprecated fields: `weight`
- Update tests accordingly

### Notes

I used the [platform.getCurrentValidators](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetcurrentvalidators) docs as a reference to update the fields.

Tests from `scripts/tests.unit.sh` are passing which make me believe that my changes on the `Id`s deserializers have no impact
