### PR TITLE
fix: Update admin endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-types"
-version = "0.0.393" # https://crates.io/crates/avalanche-types
+version = "0.0.394" # https://crates.io/crates/avalanche-types
 edition = "2021"
 rust-version = "1.69" # use "rustup override set stable" to overwrite current toolchain
 publish = true

--- a/src/jsonrpc/client/admin.rs
+++ b/src/jsonrpc/client/admin.rs
@@ -24,12 +24,12 @@ pub async fn alias_chain(
 
     let u = if let Some(scheme) = scheme {
         if let Some(port) = port {
-            format!("{scheme}://{host}:{port}/ext/info")
+            format!("{scheme}://{host}:{port}/ext/admin")
         } else {
-            format!("{scheme}://{host}/ext/info")
+            format!("{scheme}://{host}/ext/admin")
         }
     } else {
-        format!("http://{host}/ext/info")
+        format!("http://{host}/ext/admin")
     };
     log::info!("getting network name for {u}");
 


### PR DESCRIPTION
Fixes a bug where the wrong endpoint was selected for the admin commands. 

Also bumps the version.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
